### PR TITLE
removes login path from the nav bar

### DIFF
--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -13,10 +13,6 @@ const Navbar = () => {
       name:"My Recipes",
       path:"/recipes"
     },
-    {
-      name:"Login",
-      path:"/login"
-    },
   ]
 
   const [active,setActive]  = useState(0)


### PR DESCRIPTION
- [ ] removes login tab from the nav bar

The login tab was unnecessary because the nav bar will only be shown while the user is already logged in. 

![image](https://github.com/user-attachments/assets/bcb2dff0-2575-42d5-a77c-11686c89cf76)

![image](https://github.com/user-attachments/assets/d6d52e73-4772-4467-b4d5-2ec4b6cd95cc)
